### PR TITLE
Encode image URLs before rendering

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -113,7 +113,8 @@
         url = obj.url_to_image;
       }
     }
-    return url;
+    // Encode spaces and other URI components so that image links remain valid
+    return url ? encodeURI(url) : url;
   }
 
   // data load


### PR DESCRIPTION
## Summary
- Encode image URLs in `resolveImg` to handle spaces and other special characters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d1989dbbc8327be384414bf93acb4