### PR TITLE
Fix sidebar script placement in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,7 @@
     window.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhobHpob3F3bHFzaWVmeWl1cW1nIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM1NDgwOTQsImV4cCI6MjA2OTEyNDA5NH0.DnAWm_Ety74vvuRSbiSBZPuD2bCBesiDmNr8wP_mHFQ';
   </script>
   <script src="js/index.js"></script>
-</body>
-<script>
+  <script>
   const sidebar = document.querySelector('.sidebar');
   const toggleBtn = document.getElementById('sidebarToggle');
   const topicTitle = document.getElementById('selectedTopicTitle');


### PR DESCRIPTION
## Summary
- Move sidebar toggle script inside `<body>` and remove duplicate closing tag so the page loads correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d2013fae083279766fdb8e3fdbd4c