### PR TITLE
Fix Supabase script for index

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,14 +26,14 @@
     </div>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <!-- Use UMD build so window.supabase is available -->
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
   <script>
     window.SUPABASE_URL = 'https://hhlzhoqwlqsiefyiuqmg.supabase.co';
     window.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhobHpob3F3bHFzaWVmeWl1cW1nIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM1NDgwOTQsImV4cCI6MjA2OTEyNDA5NH0.DnAWm_Ety74vvuRSbiSBZPuD2bCBesiDmNr8wP_mHFQ';
   </script>
   <script src="js/index.js"></script>
-</body>
-<script>
+  <script>
   const sidebar = document.querySelector('.sidebar');
   const toggleBtn = document.getElementById('sidebarToggle');
   const topicTitle = document.getElementById('selectedTopicTitle');

--- a/js/index.js
+++ b/js/index.js
@@ -502,8 +502,11 @@
     });
   }
 
-  // Initial load
+  // Initial load: show content-area buttons if available, otherwise load data directly
   const contentAreas = await fetchContentAreas();
-  renderContentAreaButtons(contentAreas);
-  // Do not call loadData() here, only load units/topics after content area is selected
+  if (contentAreas.length) {
+    renderContentAreaButtons(contentAreas);
+  } else {
+    await loadData();
+  }
 })();


### PR DESCRIPTION
## Summary
- Load Supabase using the UMD bundle so `window.supabase` is defined
- Move sidebar toggle script inside `<body>` so it executes during page load
- Automatically load units when no content areas are returned from Supabase

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d2013fae083279766fdb8e3fdbd4c