### PR TITLE
Fix missing topic selection handler

### DIFF
--- a/js/edit_outline.js
+++ b/js/edit_outline.js
@@ -97,6 +97,14 @@ async function loadTopics(unitId) {
   topicSelect.style.background = '#ff0'; // highlight for debug
 }
 
+topicSelect.addEventListener('change', e => {
+  console.log('topicSelect changed:', e.target.value);
+  outlineFormContainer.innerHTML = '';
+  saveBtn.style.display = 'none';
+  statusMsg.textContent = '';
+  loadOutline(e.target.value);
+});
+
 async function loadOutline(topicId) {
   outlineFormContainer.innerHTML = '';
   if (!topicId) return;


### PR DESCRIPTION
## Summary
- Load lesson outline after a topic is selected on the edit page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ee18ce69883278f3b6781771ecdad