### PR TITLE
Add config files and update function env fallbacks

### DIFF
--- a/openapi/mygpt-actions.yaml
+++ b/openapi/mygpt-actions.yaml
@@ -46,6 +46,80 @@ paths:
               schema:
                 $ref: '#/components/schemas/RefineOutlineResponse'
 
+  /list_contents:
+    post:
+      operationId: listContents
+      summary: List all contents
+      security:
+        - ActionsKeyAuth: []
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListContentsResponse'
+
+  /list_units:
+    post:
+      operationId: listUnits
+      summary: List units for a content
+      security:
+        - ActionsKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListUnitsRequest'
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListUnitsResponse'
+
+  /list_topics:
+    post:
+      operationId: listTopics
+      summary: List topics with optional filters
+      security:
+        - ActionsKeyAuth: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListTopicsRequest'
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListTopicsResponse'
+
+  /get_topic:
+    post:
+      operationId: getTopic
+      summary: Get a topic by id
+      security:
+        - ActionsKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetTopicRequest'
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTopicResponse'
+
 components:
   securitySchemes:
     ActionsKeyAuth:
@@ -93,5 +167,93 @@ components:
         ok:
           type: boolean
         draft:
+          type: object
+          additionalProperties: true
+    ListContentsResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+        count:
+          type: integer
+        items:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+    ListUnitsRequest:
+      type: object
+      required: [content_id]
+      properties:
+        content_id:
+          type: string
+          format: uuid
+    ListUnitsResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+        count:
+          type: integer
+        items:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+    ListTopicsRequest:
+      type: object
+      properties:
+        limit:
+          type: integer
+        offset:
+          type: integer
+        include_drafts:
+          type: boolean
+        search:
+          type: string
+        unit_id:
+          type: string
+          format: uuid
+    ListTopicsResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+        count:
+          type: integer
+        items:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              topic:
+                type: string
+              published:
+                type: boolean
+              unit_id:
+                type: string
+                format: uuid
+                nullable: true
+              updated_at:
+                type: string
+                format: date-time
+                nullable: true
+            additionalProperties: false
+    GetTopicRequest:
+      type: object
+      required: [topic_id]
+      properties:
+        topic_id:
+          type: string
+          format: uuid
+    GetTopicResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
+        item:
           type: object
           additionalProperties: true

--- a/supabase/functions/get_topic/config.toml
+++ b/supabase/functions/get_topic/config.toml
@@ -1,0 +1,1 @@
+verify_jwt = false

--- a/supabase/functions/list_contents/config.toml
+++ b/supabase/functions/list_contents/config.toml
@@ -1,0 +1,1 @@
+verify_jwt = false

--- a/supabase/functions/list_topics/config.toml
+++ b/supabase/functions/list_topics/config.toml
@@ -1,0 +1,1 @@
+verify_jwt = false

--- a/supabase/functions/list_units/config.toml
+++ b/supabase/functions/list_units/config.toml
@@ -1,0 +1,1 @@
+verify_jwt = false

--- a/supabase/functions/refine_outline/index.ts
+++ b/supabase/functions/refine_outline/index.ts
@@ -2,11 +2,15 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
-const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const SUPABASE_SECRET_KEY =
+  Deno.env.get("SUPABASE_SECRET_KEY") ??
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 const ACTIONS_ADMIN_KEY = Deno.env.get("ACTIONS_ADMIN_KEY")!;
-const OPEN_API_KEY = Deno.env.get("OPEN_API_KEY")!;
+const OPENAI_API_KEY =
+  Deno.env.get("OPENAI_API_KEY") ??
+  Deno.env.get("OPEN_API_KEY")!;
 
-const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+const supabase = createClient(SUPABASE_URL, SUPABASE_SECRET_KEY);
 
 serve(async (req) => {
   try {
@@ -55,7 +59,7 @@ serve(async (req) => {
     // Call OpenAI (chat completions JSON response)
     const oai = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
-  headers: { Authorization: `Bearer ${OPEN_API_KEY}`, "Content-Type": "application/json" },
+  headers: { Authorization: `Bearer ${OPENAI_API_KEY}`, "Content-Type": "application/json" },
       body: JSON.stringify({
         model: "gpt-4o-mini",
         temperature: 0.2,

--- a/supabase/functions/update_outline/index.ts
+++ b/supabase/functions/update_outline/index.ts
@@ -3,10 +3,12 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
-const SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const SUPABASE_SECRET_KEY =
+  Deno.env.get("SUPABASE_SECRET_KEY") ??
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 const ACTIONS_ADMIN_KEY = Deno.env.get("ACTIONS_ADMIN_KEY")!;
 
-const supabase = createClient(SUPABASE_URL, SERVICE_ROLE_KEY);
+const supabase = createClient(SUPABASE_URL, SUPABASE_SECRET_KEY);
 
 serve(async (req) => {
   try {


### PR DESCRIPTION
## Summary
- Add config.toml for list_contents, list_units, list_topics, and get_topic with `verify_jwt = false`
- Add SUPABASE_SECRET_KEY and OPENAI_API_KEY fallbacks in outline functions
- Expand OpenAPI spec with list/get endpoints and schemas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abd932056c8327a6174f734b3c7b4c