### PR TITLE
Allow frontend outline editing for all authenticated users

### DIFF
--- a/js/edit_outline.js
+++ b/js/edit_outline.js
@@ -17,6 +17,7 @@ var currentSchemaVersion = 1; // 1 or 2
 document.addEventListener('DOMContentLoaded', function () {
   // --- Setup ---
   var SUPABASE_URL = window.SUPABASE_URL || 'https://hhlzhoqwlqsiefyiuqmg.supabase.co';
+  var FUNCTIONS_URL = SUPABASE_URL.replace('.supabase.co', '.functions.supabase.co');
   var SUPABASE_PUBLISHABLE_KEY =
     window.SUPABASE_PUBLISHABLE_KEY || 'sb_publishable_z5FpORNEIA4S6kOY-Mdzxw_YtBllO9n';
 

--- a/supabase/functions/update_outline_auth/index.ts
+++ b/supabase/functions/update_outline_auth/index.ts
@@ -98,8 +98,10 @@ Deno.serve(async (req) => {
 
 function isAllowed(email: string) {
   if (!email) return false;
+  // If no restrictions are configured, allow any authenticated user
+  if (!ALLOWED_EMAIL_DOMAIN && ALLOWED_EDITOR_EMAILS.length === 0) return true;
   if (ALLOWED_EDITOR_EMAILS.includes(email)) return true;
-  if (ALLOWED_EMAIL_DOMAIN && email.endsWith("@"+ALLOWED_EMAIL_DOMAIN)) return true;
+  if (ALLOWED_EMAIL_DOMAIN && email.endsWith("@" + ALLOWED_EMAIL_DOMAIN)) return true;
   return false; // default deny
 }
 


### PR DESCRIPTION
## Summary
- Allow any authenticated user to save lesson outlines when no email allow-list is set
- Define Supabase Functions URL used by the outline editor's fallback save path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad03d070dc83278a12ecc87a62f5db