### PR TITLE
Load outline requests after sign-in

### DIFF
--- a/js/edit_outline.js
+++ b/js/edit_outline.js
@@ -663,6 +663,9 @@ async function refreshAuthUI() {
 // Handle state changes (e.g., after clicking the magic link)
 supa.auth.onAuthStateChange(function (_event, session) {
   updateAuthUI(session);
+  if (_event === 'SIGNED_IN' && session) {
+    loadRequests();
+  }
 });
 
 // Send magic link


### PR DESCRIPTION
## Summary
- refresh requests list upon successful Supabase sign-in

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad0b008c488327acaf76aa6fc6c46e