### PR TITLE
Load requests only when authenticated after topic query resolution

### DIFF
--- a/js/edit_outline.js
+++ b/js/edit_outline.js
@@ -697,7 +697,10 @@ refreshAuthUI();
 
 
   // Init
-  tryOpenFromQuery().then(function(hit){
-    if (!hit) loadRequests();
+  tryOpenFromQuery().then(async function(){
+    var s = await supa.auth.getSession();
+    if (s && s.data && s.data.session) {
+      loadRequests();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Remove unconditional `loadRequests` call after `tryOpenFromQuery`
- Check current session and only load requests when authenticated

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad14db703c83279af2168f62fa5373