### PR TITLE
Use secure view for editing outlines

### DIFF
--- a/js/edit_outline.js
+++ b/js/edit_outline.js
@@ -110,7 +110,7 @@ document.addEventListener('DOMContentLoaded', function () {
     var unitIds = units.map(function(x){ return x.id; });
 
     var t = await supa
-      .from('lesson_outlines_public') // read view
+      .from('edit_outline_view') // read view
       .select('*')
       .in('unit_id', unitIds)
       .order('topic_title', { ascending: true });

--- a/supabase/sql/edit_outline_view.sql
+++ b/supabase/sql/edit_outline_view.sql
@@ -1,0 +1,1 @@
+grant select on table public.edit_outline_view to authenticated;


### PR DESCRIPTION
## Summary
- query lesson outlines from `edit_outline_view` in editor
- grant authenticated users select privileges on `edit_outline_view`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad1569fba48327866286677bba2fe1