### PR TITLE
docs: update MyGPT actions reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Project Structure
 │           ├── index.ts     # AI refinement via OpenAI
 │           └── config.toml
 ├── openapi/
-│   └── mygpt-actions.yaml   # OpenAPI spec for MyGPT Actions
+│   ├── mygpt-actions.json             # OpenAPI spec for MyGPT Actions
+│   └── mygpt-actions.yaml.deprecated  # Legacy spec (do not upload)
 ├── .env.example             # Environment template (do not commit .env)
 └── README.md                # This file
 
@@ -90,7 +91,8 @@ npx supabase functions deploy refine_outline
 
 3. MyGPT Actions
 
-Upload openapi/mygpt-actions.yaml in MyGPT → Actions → Add
+Upload openapi/mygpt-actions.json in MyGPT → Actions → Add
+Note: openapi/mygpt-actions.yaml.deprecated is a legacy spec and should not be uploaded.
 
 Set auth header: Authorization: Bearer <ACTIONS_ADMIN_KEY>
 


### PR DESCRIPTION
## Summary
- document `openapi/mygpt-actions.json` as the spec for MyGPT Actions
- highlight `openapi/mygpt-actions.yaml.deprecated` as legacy and not for upload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad19b71e0083278e382fdf8f797d85